### PR TITLE
Add derive EnumCommonFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Provides traits and "derives" for enum items in the Rust programming language:
 - EnumIter
 - EnumIterator
 - EnumVariantName
+- EnumCommonFields
 
 ### Traits ###
 - Index

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,35 @@
 //! Simple traits for builtin enum items.
 //! Primarily used by `enum_traits_macros` when automatically deriving types.
 //! The crate `enum_traits_macros` is required for the derives.
+//!
+//! ## EnumCommonFields
+//!
+//! Using `#[derive(EnumCommonFields)]` on enums containing exclusively struct variants
+//! will implement member functions for all struct fields with the same name and type.
+//!
+//! ### Examples
+//!
+//! ```ignore
+//! #[derive(Debug, EnumCommonFields)]
+//! enum Enum {
+//!     Cat{age: u32},
+//!     Dog{age: u32},
+//!     Robot{age: u32},
+//! }
+//! assert_eq!(Enum::Dog{age: 3}.age(), &3);
+//! ```
+//!
+//! ```ignore
+//! #[derive(Debug, PartialEq, EnumCommonFields)]
+//! enum Enum {
+//!     Cat{age: u32},
+//!     Dog{age: u32},
+//!     Robot{age: u32},
+//! }
+//! let mut d = Enum::Dog{age: 3};
+//! *d.age_mut() = 5;
+//! assert_eq!(d, Enum::Dog{age: 5});
+//! ```
 
 #![feature(associated_consts)]
 

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -370,6 +370,73 @@ fn variant_name() {
 
 #[test]
 #[allow(dead_code)]
+fn common_fields() {
+    {
+		#[derive(Debug,EnumCommonFields)]
+		enum Enum {
+			Dog{age: u32},
+			Cat{age: u32},
+			Robot{age: u32},
+		}
+		assert_eq!(Enum::Dog{age: 3}.age(), &3);
+	}
+	{
+		#[derive(Debug,EnumCommonFields)]
+		enum Enum {
+			Dog{age: u32},
+			Cat{age: u32},
+			Robot{age: u32, speed: f32},
+		}
+		assert_eq!(Enum::Dog{age: 3}.age(), &3);
+		assert_eq!(Enum::Robot{age: 7, speed: 90.0}.age(), &7);
+	}
+	{
+		#[derive(Debug,EnumCommonFields)]
+		enum Enum {
+			Dog{age: u32, speed: f32},
+			Cat{age: u32, speed: f32},
+			Robot{age: u32, speed: f32},
+		}
+		assert_eq!(Enum::Dog{age: 3, speed: 20.0}.age(), &3);
+		assert_eq!(Enum::Robot{age: 7, speed: 90.0}.speed(), &90.0);
+	}
+	{
+		#[derive(Debug,EnumCommonFields)]
+		enum Enum {
+			Dog{age: u32},
+			Cat{age: u32},
+			Robot{age: u32},
+		}
+
+		impl Enum {
+			pub fn zero(&mut self) -> usize {
+				0
+			}
+		}
+
+		assert_eq!(Enum::Dog{age: 3}.age(), &3);
+		assert_eq!(Enum::Dog{age: 3}.zero(), 0);
+	}
+}
+
+#[test]
+#[allow(dead_code)]
+fn common_fields_mut() {
+	{
+		#[derive(Debug,PartialEq,EnumCommonFields)]
+		enum Enum {
+			Dog{age: u32},
+			Cat{age: u32},
+			Robot{age: u32},
+		}
+		let mut d = Enum::Dog{age: 3};
+		*d.age_mut() = 5;
+		assert_eq!(d, Enum::Dog{age: 5});
+	}
+}
+
+#[test]
+#[allow(dead_code)]
 fn f1(){
 	#[derive(Debug,EnumIndex,EnumToIndex,EnumLen)]
 	enum Enum<'t,T: 't>{


### PR DESCRIPTION
This is not a trait, so I can understand if you don't want to merge it but I think it fits here best.

Using `#[derive(EnumCommonFields)]` on enums containing exclusively struct variants will implement member functions for all struct fields with the same name and type.

Examples:

```
#[derive(Debug, EnumCommonFields)]
enum Enum {
    Cat{age: u32},
    Dog{age: u32},
    Robot{age: u32},
}
assert_eq!(Enum::Dog{age: 3}.age(), &3);
```

```
#[derive(Debug, PartialEq, EnumCommonFields)]
enum Enum {
    Cat{age: u32},
    Dog{age: u32},
    Robot{age: u32},
}
let mut d = Enum::Dog{age: 3};
*d.age_mut() = 5;
assert_eq!(d, Enum::Dog{age: 5});
```
